### PR TITLE
Update Repos.js

### DIFF
--- a/src/components/Repos.js
+++ b/src/components/Repos.js
@@ -42,7 +42,7 @@ const Repos = () => {
   let { stars, forks } = repos.reduce(
     (total, item) => {
       const { stargazers_count, name, forks } = item;
-      total.stars[stargazers_count] = { label: name, value: stargazers_count };
+      total.stars[name] = { label: name, value: stargazers_count };
       total.forks[forks] = { label: name, value: forks };
       return total;
     },


### PR DESCRIPTION
If we have two or more repos with same "stargazer_count" value then it was replacing old one with new one. Replacing it with "name" can be a better option since its unique for every repo.